### PR TITLE
Fix: filter by image digest rather than image tag

### DIFF
--- a/samples/occurrencesForImage.js
+++ b/samples/occurrencesForImage.js
@@ -20,9 +20,9 @@
 //   usage: node occurrencesForImage.js "project-id" "image-url"
 async function main(
   projectId = 'your-project-id', // Your GCP Project ID
-  imageUrl = 'https://gcr.io/my-project/my-image:123' // Image to attach metadata to
+  imageUrl = 'https://gcr.io/my-project/my-image@sha256:123' // Image to attach metadata to
   // If you are using Google Artifact Registry
-  // imageUrl = 'https://LOCATION-docker.pkg.dev/my-project/my-repo/my-image:123' // Image to attach metadata to
+  // imageUrl = 'https://LOCATION-docker.pkg.dev/my-project/my-repo/my-image@sha256:123' // Image to attach metadata to
 ) {
   // [START containeranalysis_occurrences_for_image]
   /**
@@ -30,9 +30,9 @@ async function main(
    */
   // const projectId = 'your-project-id', // Your GCP Project ID
   // If you are using Google Container Registry
-  // const imageUrl = 'https://gcr.io/my-project/my-repo/my-image:123' // Image to attach metadata to
+  // const imageUrl = 'https://gcr.io/my-project/my-repo/my-image@sha256:123' // Image to attach metadata to
   // If you are using Google Artifact Registry
-  // const imageUrl = 'https://LOCATION-docker.pkg.dev/my-project/my-repo/my-image:123' // Image to attach metadata to
+  // const imageUrl = 'https://LOCATION-docker.pkg.dev/my-project/my-repo/my-image@sha256:123' // Image to attach metadata to
 
   // Import the library and create a client
   const {ContainerAnalysisClient} = require('@google-cloud/containeranalysis');


### PR DESCRIPTION
This example should filter by image digest (@sha256:123), similar to the samples for Python, Ruby, and others on this page: https://cloud.google.com/container-analysis/docs/automated-scanning-howto#container-analysis-discovery-python

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-containeranalysis/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #454 🦕
